### PR TITLE
fix：一键式启动（降低风控版）+补全requirement

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,16 +43,28 @@ def login_study(driver,phone_number,password):
     无。
     """
     # 打开网页
-    driver.get("https:i.chaoxing.com/")
+      driver.get("https:i.chaoxing.com/")
     turn_page(driver,'用户登录')
+    # 尝试 cookie.pkl 自动登录（宿主 profile 或手动导入均可）
+    if auto_login_with_cookies(driver):
+        if get_cookie(driver):
+            print(color.green('Cookie 登录成功'), flush=True)
+        return
+    # 已登录状态（页面无登录框）
+    try:
+        driver.find_element(By.ID, 'phone')
+    except:
+        print(color.green('检测到已登录状态，跳过登录步骤'), flush=True)
+        if get_cookie(driver):
+            print(color.green('登录成功'), flush=True)
+        return
+    # 输账密登录
     print(color.green('正在登录中...'), flush=True)
-    # 自动登录
     element = driver.find_element(By.ID, 'phone')
     time.sleep(1)
     element1 = driver.find_element(By.ID, 'pwd')
-    element.send_keys(phone_number)  # 替换成你的手机号码
-    element1.send_keys(password)  # 替换成你的密码
-    # 点击登录
+    element.send_keys(phone_number)
+    element1.send_keys(password)
     login_button = driver.find_element(By.ID, 'loginBtn')
     try:
         login_button.click()

--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ def login_study(driver,phone_number,password):
     无。
     """
     # 打开网页
-      driver.get("https:i.chaoxing.com/")
+    driver.get("https://i.chaoxing.com/")
     turn_page(driver,'用户登录')
     # 尝试 cookie.pkl 自动登录（宿主 profile 或手动导入均可）
     if auto_login_with_cookies(driver):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+# Xuexitong_shuake_mod1 依赖
+# 安装: pip install -r requirements.txt
+
+customtkinter>=5.2.0
+selenium>=4.15.0
+PyAutoGUI>=0.9.53
+requests>=2.28.0
+Pillow>=9.0.0
+colorama>=0.4.6
+fonttools>=4.0.0
+openai>=1.0.0


### PR DESCRIPTION
# 低风控免扫码
​不再是开一个单独环境隔离的浏览器强行注入cookie！
这样很容易环境校验不通过弹人脸，而且debug不方便重启一次服务又是一个新的浏览器，没有对照意义
​使用宿主profile，直接调用浏览器本体的指纹参数和缓存cookie，降低风控（此次提交源码）
创作者OpenClaw，请使用Jun4那个手动修复了混乱的缩进
# ​进阶玩法（建议探索）：
先启动浏览器开启remote-debugging-port再由程序接管，可以做到不同人的信息隔离（你懂的）这里不再列出
可以丢给ai分析或者参考我另一个project(thunder-cloud-decompress)的bat脚本
​